### PR TITLE
Change it so '_' counts as word boundary and fix regexes

### DIFF
--- a/jai-mode.el
+++ b/jai-mode.el
@@ -42,7 +42,6 @@
     (modify-syntax-entry ?\\ "\\" table)
 
     ;; additional symbols
-    (modify-syntax-entry ?_ "w" table)
 
     (modify-syntax-entry ?' "." table)
     (modify-syntax-entry ?: "." table)
@@ -83,7 +82,7 @@
     "bool"))
 
 (defun jai-wrap-word-rx (s)
-  (concat "\\<" s "\\>"))
+  (concat "\\_<" s "\\_>"))
 
 (defun jai-keywords-rx (keywords)
   "build keyword regexp"
@@ -110,10 +109,10 @@
     (,(jai-keywords-rx jai-builtins) 1 font-lock-variable-name-face)
 
     ;; Hash directives
-    ("#\\w+" . font-lock-preprocessor-face)
+    ("#[[:word:]_]+" . font-lock-preprocessor-face)
 
     ;; At notes
-    ("@\\w+" . font-lock-preprocessor-face)
+    ("@[[:word:]_]+" . font-lock-preprocessor-face)
 
     ;; Strings
     ("\\\".*\\\"" . font-lock-string-face)


### PR DESCRIPTION
Changing so _ counts as word boundary for easyness of editing 'M-f' and so on, to avoid this breaking highlighting some regexes need modifying.